### PR TITLE
Removed unsupported flag (--allowed-plugin) being passed to 'fetch-eb…

### DIFF
--- a/lib.sh
+++ b/lib.sh
@@ -692,7 +692,7 @@ fetch_metadata() {
 
 	local isbn_source="" args=()
 	for isbn_source in "${isbn_sources[@]:-}"; do
-		args+=("${isbn_source:+--allowed-plugin=$isbn_source}")
+		args+=("${isbn_source:+}")
 	done
 
 	decho "Calling fetch-ebook-metadata --verbose" "${args[*]}" "${@:3}"


### PR DESCRIPTION
Hi,  

I had an issue when I was running the release version (ebook-tools-0.5.1) where I was getting an error message "Could not fetch metadata for ISBNs" for all the books I was testing. On closer inspection it seemed the script was calling: ```fetch-ebook-metadata --verbose --allowed-plugin=Amazon.com --isbn=1111``` but the ```fetch-ebook-metadata``` script did not support the flag  ```--allowed-plugin=Amazon.com```. I have removed passing the flag to the ```fetch-ebook-metadata```  script within ```lib.sh``` for this pull request. I am not sure if support for the ``` --allowed-plugin=Amazon.com``` should rather be added to ```fetch-ebook-metadata``` or if it was just mistakenly called and a removal should be the answer.
&nbsp;  
This is the full command I ran:  
&nbsp;  

```shell
./organize-ebooks.sh --output-folder-pamphlets=/media/pamp -ocr=true -v --output-folder=/media/organised  --output-folder-uncertain=/media/uncertain --keep-metadata /media/test


